### PR TITLE
fix bug with admin editing

### DIFF
--- a/app/views/user_applications/_form.html.erb
+++ b/app/views/user_applications/_form.html.erb
@@ -22,7 +22,7 @@
   </div>
 
   <div class="my-5">
-    <%= form.hidden_field :user_id, value: current_user.id %>
+    <%= form.hidden_field :user_id, value: user_application.user_id || current_user.id %>
   </div>
 
   <div class="my-5">


### PR DESCRIPTION
This PR fixes a bug where if an admin edits a user's application, the user_id associated with the application would change to the admin's user id. 